### PR TITLE
Maintenance mode with request retention mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@
 - Custom HTML template support
 - Configurable retry period
 
+## 💡 Benefits
+- Centralized control through Caddy
+- No need to modify application code
+- Clean customised user experience during maintenance
+- SEO friendly interruption
+- Perfect for containerized architectures
+- Reduced manual intervention needs
+
 ## 🔧 Build caddy with plugin
 
   ```shell
@@ -90,6 +98,15 @@ Add the maintenance directive to your Caddyfile:
        http://localhost:2019/maintenance/set
   ```
 
+### Enable Maintenance Mode with request retention for 10 seconds
+
+  ```shell
+  curl -X POST \
+       -H "Content-Type: application/json" \
+       -d '{"enabled": true, "request_retention_mode_timeout": 10}' \
+       http://localhost:2019/maintenance/set
+  ```
+
 ### Disable Maintenance Mode
 
   ```shell
@@ -99,38 +116,14 @@ Add the maintenance directive to your Caddyfile:
        http://localhost:2019/maintenance/set
   ```
 
-## 📊 Performance Impact
-
-The maintenance module has been thoroughly benchmarked using ApacheBench with the following test conditions:
-- 1 million requests
-- 100 concurrent connections
-- Document size: 12 bytes
-- Test duration: ~73 seconds
-
-### Benchmark Results
-
-The maintenance module shows negligible performance impact:
-- Less than 1% decrease in request handling capacity
-- Sub-millisecond increase in response time
-- Perfect reliability maintained with zero failed requests
-
-| Metric | Vanilla Caddy | With Maintenance Module | Impact |
-|--------|---------------|------------------------|--------|
-| Requests/sec | 13,638 | 13,528 | -0.81% |
-| Time per request | 7.332ms | 7.392ms | +0.82% |
-| Transfer rate | 1,917.91 KB/sec | 1,902.38 KB/sec | -0.81% |
-| Failed requests | 0 | 0 | None |
-
 ## Real World Use Cases
 
 ### Website Maintenance Management Made Easy
 
-Managing maintenance windows for any web platform can be challenging, especially in modern architectures. Here's how this plugin simplifies the process:
-
 **Scenario**: 
 - Web platform running as a Docker stack
 - Caddy serving as the main entry point/reverse proxy
-- Need for controlled maintenance periods to deploy new versions of the application
+- Need for controlled maintenance periods to deploy new release or perform maintenance tasks
 
 **Solution**:
 The maintenance plugin enables seamless maintenance mode activation by:
@@ -140,12 +133,18 @@ The maintenance plugin enables seamless maintenance mode activation by:
 4. Safely performing required maintenance tasks, deployment, container rebuilds, etc.
 5. Restoring service when ready
 
-**Benefits**:
-- Centralized control through Caddy
-- No need to modify application code
-- Clean customised user experience during maintenance
-- SEO friendly interruption
-- Perfect for containerized architectures
+### Micro Maintenance with requests retention
+
+**Scenario**: 
+- Web platform running as a Docker stack
+- Caddy serving as the main entry point/reverse proxy
+- Need for short maintenance periods to perform quick tasks without service interruption
+
+**Solution**:
+1. Toggling maintenance on through API call to Caddy's admin interface with request retention timeout configuration 
+2. Caddy instantly retain incoming requests for the predefined period until maintenance mode is disabled or display a maintenance page if timeout is reached
+3. Toggling maintenance off through API, the retained requests are released and forwarded to the backend
+
 
 ### Automated Maintenance Based on Critical Services Health
 
@@ -163,13 +162,6 @@ The maintenance plugin can be integrated with Docker health checks:
 2. Custom script watches for health status changes
 3. Maintenance mode automatically triggered when critical service fails
 4. System remains protected until services are healthy again
-
-**Benefits**:
-- Automatic protection of system integrity
-- Immediate response to infrastructure issues
-- Clear communication to end users
-- Prevention of data corruption
-- Reduced manual intervention needs
 
 
 ## 👩‍💻 Development

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,21 @@
+## 📊 Performance Impact
+
+The maintenance module has been thoroughly benchmarked using ApacheBench with the following test conditions:
+- 1 million requests
+- 100 concurrent connections
+- Document size: 12 bytes
+- Test duration: ~73 seconds
+
+### Benchmark Results
+
+The maintenance module shows negligible performance impact:
+- Less than 1% decrease in request handling capacity
+- Sub-millisecond increase in response time
+- Perfect reliability maintained with zero failed requests
+
+| Metric | Vanilla Caddy | With Maintenance Module | Impact |
+|--------|---------------|------------------------|--------|
+| Requests/sec | 13,638 | 13,528 | -0.81% |
+| Time per request | 7.332ms | 7.392ms | +0.82% |
+| Transfer rate | 1,917.91 KB/sec | 1,902.38 KB/sec | -0.81% |
+| Failed requests | 0 | 0 | None |

--- a/fopsMaintenanceAdminApi.go
+++ b/fopsMaintenanceAdminApi.go
@@ -70,7 +70,8 @@ func (h AdminHandler) toggle(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	var req struct {
-		Enabled bool `json:"enabled"`
+		Enabled                     bool `json:"enabled"`
+		RequestRetentionModeTimeout int  `json:"request_retention_mode_timeout,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -90,6 +91,7 @@ func (h AdminHandler) toggle(w http.ResponseWriter, r *http.Request) error {
 
 	maintenanceHandler.enabledMux.Lock()
 	maintenanceHandler.enabled = req.Enabled
+	maintenanceHandler.RequestRetentionModeTimeout = req.RequestRetentionModeTimeout
 	maintenanceHandler.enabledMux.Unlock()
 
 	return json.NewEncoder(w).Encode(map[string]bool{

--- a/fopsMaintenance_test.go
+++ b/fopsMaintenance_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -635,45 +636,178 @@ func TestMaintenanceHandlerRequestRetentionMode(t *testing.T) {
 }
 
 func TestParseCaddyfileRequestRetentionModeTimeout(t *testing.T) {
-	// Test cases
 	tests := []struct {
-		name                 string
-		input                string
-		expectedTimeout      int
-		expectedErrorMessage string
+		name          string
+		input         string
+		expectedError bool
+		expected      *MaintenanceHandler
 	}{
 		{
-			name:            "Valid request_retention_mode_timeout",
-			input:           "maintenance {\nrequest_retention_mode_timeout 60\n}",
-			expectedTimeout: 60,
+			name: "Valid request_retention_mode_timeout",
+			input: `maintenance {
+					request_retention_mode_timeout 30
+				}`,
+			expectedError: false,
+			expected: &MaintenanceHandler{
+				RequestRetentionModeTimeout: 30,
+			},
 		},
 		{
-			name:                 "Invalid request_retention_mode_timeout",
-			input:                "maintenance {\nrequest_retention_mode_timeout invalid\n}",
-			expectedErrorMessage: "invalid request_retention_mode_timeout value",
+			name: "Missing request_retention_mode_timeout value",
+			input: `maintenance {
+					request_retention_mode_timeout
+				}`,
+			expectedError: true,
+			expected:      nil,
 		},
 		{
-			name:                 "Negative request_retention_mode_timeout",
-			input:                "maintenance {\nrequest_retention_mode_timeout -10\n}",
-			expectedErrorMessage: "request_retention_mode_timeout value must be positive",
+			name: "Invalid request_retention_mode_timeout value",
+			input: `maintenance {
+					request_retention_mode_timeout invalid
+				}`,
+			expectedError: true,
+			expected:      nil,
+		},
+		{
+			name: "Negative request_retention_mode_timeout value",
+			input: `maintenance {
+					request_retention_mode_timeout -10
+				}`,
+			expectedError: true,
+			expected:      nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := httpcaddyfile.Helper{
-				Dispenser: caddyfile.NewTestDispenser(tt.input),
-			}
+			d := caddyfile.NewTestDispenser(tt.input)
+			h := httpcaddyfile.Helper{Dispenser: d}
 
-			m, err := parseCaddyfile(h)
+			actual, err := parseCaddyfile(h)
 
-			if tt.expectedErrorMessage != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectedErrorMessage)
+			if tt.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, actual)
 			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expectedTimeout, m.(*MaintenanceHandler).RequestRetentionModeTimeout)
+				assert.NoError(t, err)
+				actualHandler, ok := actual.(*MaintenanceHandler)
+				assert.True(t, ok)
+				assert.Equal(t, tt.expected.RequestRetentionModeTimeout, actualHandler.RequestRetentionModeTimeout)
 			}
 		})
 	}
+}
+
+func TestMaintenanceHandlerRequestRetentionModeWithDisable(t *testing.T) {
+	// Create context with timeout
+	ctx, cancel := caddy.NewContext(caddy.Context{Context: context.Background()})
+	defer cancel()
+
+	// Create handler with retention mode of 30 seconds
+	h := &MaintenanceHandler{
+		HTMLTemplate:                defaultHTMLTemplate,
+		RequestRetentionModeTimeout: 30,
+		ctx:                         ctx,
+	}
+
+	// Enable maintenance mode initially
+	h.enabledMux.Lock()
+	h.enabled = true
+	h.enabledMux.Unlock()
+
+	// Create test request
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+
+	// Create response recorder
+	w := httptest.NewRecorder()
+
+	// Create next handler that sets a specific header to verify it was called
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		w.Header().Set("X-Test", "request-processed")
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	// Launch request processing in a goroutine
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- h.ServeHTTP(w, req, next)
+	}()
+
+	// Wait a short time to ensure request is being held
+	time.Sleep(2 * time.Second)
+
+	// Disable maintenance mode
+	h.enabledMux.Lock()
+	h.enabled = false
+	h.enabledMux.Unlock()
+
+	// Wait for the request to complete
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Request did not complete in time")
+	}
+
+	// Verify that the request was processed by the next handler
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "request-processed", w.Header().Get("X-Test"))
+}
+
+func TestMaintenanceHandlerRequestRetentionModeWithPeriodicCheck(t *testing.T) {
+	// Create context with timeout
+	ctx, cancel := caddy.NewContext(caddy.Context{Context: context.Background()})
+	defer cancel()
+
+	// Create handler with retention mode of 30 seconds
+	h := &MaintenanceHandler{
+		HTMLTemplate:                defaultHTMLTemplate,
+		RequestRetentionModeTimeout: 30,
+		ctx:                         ctx,
+	}
+
+	// Enable maintenance mode initially
+	h.enabledMux.Lock()
+	h.enabled = true
+	h.enabledMux.Unlock()
+
+	// Create test request
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+
+	// Create response recorder
+	w := httptest.NewRecorder()
+
+	// Create next handler that sets a specific header to verify it was called
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		w.Header().Set("X-Test", "request-processed")
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	// Launch request processing in a goroutine
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- h.ServeHTTP(w, req, next)
+	}()
+
+	// Wait slightly longer than 1 second to ensure we hit the periodic check
+	time.Sleep(1100 * time.Millisecond)
+
+	// Disable maintenance mode
+	h.enabledMux.Lock()
+	h.enabled = false
+	h.enabledMux.Unlock()
+
+	// Wait for the request to complete
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Request did not complete in time")
+	}
+
+	// Verify that the request was processed by the next handler
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "request-processed", w.Header().Get("X-Test"))
 }


### PR DESCRIPTION
# Request Retention Mode for Maintenance Handler

## Description

This PR introduces a new "Request Retention Mode" feature that allows for smoother maintenance transitions by temporarily holding incoming requests instead of immediately serving maintenance pages.

### Key Features

- Configurable request retention timeout
- Requests are held in memory during the retention period
- Automatic release of held requests when maintenance mode is disabled (1sec max)
- Fallback to maintenance page if timeout is reached

### Benefits

- Zero-downtime maintenance for quick operations
- Improved user experience during brief maintenance windows
- Perfect for rolling updates and quick infrastructure changes
