### PR TITLE
fix : allowed ip management

### DIFF
--- a/fopsMaintenance.go
+++ b/fopsMaintenance.go
@@ -3,6 +3,7 @@ package fopsMaintenance
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -89,6 +90,9 @@ func (h *MaintenanceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, n
 
 	// Check if client IP is in allowed list
 	clientIP := r.RemoteAddr
+	if host, _, err := net.SplitHostPort(clientIP); err == nil {
+		clientIP = host
+	}
 	for _, allowedIP := range h.AllowedIPs {
 		if clientIP == allowedIP {
 			return next.ServeHTTP(w, r)

--- a/fopsMaintenance_test.go
+++ b/fopsMaintenance_test.go
@@ -377,6 +377,24 @@ func TestMaintenanceHandler_ServeHTTP_AllowedIPs(t *testing.T) {
 			clientIP:      "192.168.1.100",
 			expectBlocked: true,
 		},
+		{
+			name:          "Allowed IP with port should bypass maintenance",
+			allowedIPs:    []string{"192.168.1.100"},
+			clientIP:      "192.168.1.100:12345",
+			expectBlocked: false,
+		},
+		{
+			name:          "Non-allowed IP with port should see maintenance page",
+			allowedIPs:    []string{"192.168.1.100"},
+			clientIP:      "192.168.1.101:12345",
+			expectBlocked: true,
+		},
+		{
+			name:          "Real world IP should bypass maintenance",
+			allowedIPs:    []string{"90.24.160.89"},
+			clientIP:      "90.24.160.89:54321",
+			expectBlocked: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Fixed allowed IPs verification to handle IP addresses with ports (format `IP:PORT`)
  - The fix now properly extracts the IP from the full address before comparison
  - Added comprehensive unit tests to validate this behavior