### PR TITLE
add default maintenance mode state at startup with `default_enabled` …

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Add the maintenance directive to your Caddyfile:
 | `template` | Path to custom HTML template | No |
 | `allowed_ips` | List of IPs that can access during maintenance | No |
 | `retry_after` | Retry-After header value in seconds | No |
+| `default_enabled` | Enable maintenance mode by default at startup | No |
+| `status_file` | Path to file for persisting maintenance status | No |
+| `request_retention_mode_timeout` | Time in seconds to retain requests during maintenance | No |
 
 ## 🚀 API Reference
 
@@ -115,6 +118,37 @@ Add the maintenance directive to your Caddyfile:
        -d '{"enabled": false}' \
        http://localhost:2019/maintenance/set
   ```
+
+## Advanced Configuration Examples
+
+### Default Maintenance Mode for Pre-production Environments
+
+```caddy
+preprod.example.com {
+  maintenance {
+    # Enable maintenance by default at startup
+    default_enabled true
+    # Allow specific IPs to access during maintenance
+    allowed_ips 192.168.1.100 10.0.0.1
+    # Custom template
+    template "/path/to/template.html"
+  }
+}
+```
+
+### Persistent Maintenance Status
+
+```caddy
+example.com {
+  maintenance {
+    # Persist maintenance status to survive restarts
+    status_file /var/lib/caddy/maintenance.json
+    # Retry-After header value in seconds
+    retry_after 300
+  }
+}
+```
+
 
 ## Real World Use Cases
 

--- a/fopsMaintenanceAdminApi.go
+++ b/fopsMaintenanceAdminApi.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 
 	"github.com/caddyserver/caddy/v2"
@@ -93,6 +94,28 @@ func (h AdminHandler) toggle(w http.ResponseWriter, r *http.Request) error {
 	maintenanceHandler.enabled = req.Enabled
 	maintenanceHandler.RequestRetentionModeTimeout = req.RequestRetentionModeTimeout
 	maintenanceHandler.enabledMux.Unlock()
+
+	// Persist status if StatusFile is configured
+	if maintenanceHandler.StatusFile != "" {
+		status := struct {
+			Enabled bool `json:"enabled"`
+		}{
+			Enabled: req.Enabled,
+		}
+		data, err := json.Marshal(status)
+		if err != nil {
+			return caddy.APIError{
+				HTTPStatus: http.StatusInternalServerError,
+				Err:        fmt.Errorf("failed to marshal status: %v", err),
+			}
+		}
+		if err := os.WriteFile(maintenanceHandler.StatusFile, data, 0644); err != nil {
+			return caddy.APIError{
+				HTTPStatus: http.StatusInternalServerError,
+				Err:        fmt.Errorf("failed to persist status: %v", err),
+			}
+		}
+	}
 
 	return json.NewEncoder(w).Encode(map[string]bool{
 		"enabled": req.Enabled,

--- a/fopsMaintenanceAdminApi.go
+++ b/fopsMaintenanceAdminApi.go
@@ -13,7 +13,21 @@ import (
 var (
 	maintenanceHandlerInstance *MaintenanceHandler
 	instanceMux                sync.RWMutex
+	// For testing purposes only
+	jsonMarshalFunc = json.Marshal
 )
+
+// ResetJSONMarshal resets the JSON marshal function to the default
+// This is for testing purposes only
+func ResetJSONMarshal() {
+	jsonMarshalFunc = json.Marshal
+}
+
+// SetJSONMarshalFunc sets a custom JSON marshal function
+// This is for testing purposes only
+func SetJSONMarshalFunc(fn func(interface{}) ([]byte, error)) {
+	jsonMarshalFunc = fn
+}
 
 func init() {
 	caddy.RegisterModule(AdminHandler{})
@@ -102,7 +116,7 @@ func (h AdminHandler) toggle(w http.ResponseWriter, r *http.Request) error {
 		}{
 			Enabled: req.Enabled,
 		}
-		data, err := json.Marshal(status)
+		data, err := jsonMarshalFunc(status)
 		if err != nil {
 			return caddy.APIError{
 				HTTPStatus: http.StatusInternalServerError,


### PR DESCRIPTION
- Default maintenance mode state at startup with `default_enabled` option
- Persistence of maintenance status with `status_file` option

### Default Maintenance Mode for Pre-production Environments

```caddy
preprod.example.com {
  maintenance {
    # Enable maintenance by default at startup
    default_enabled true
    # Allow specific IPs to access during maintenance
    allowed_ips 192.168.1.100 10.0.0.1
    # Custom template
    template "/path/to/template.html"
  }
}
```

### Persistent Maintenance Status

```caddy
example.com {
  maintenance {
    # Persist maintenance status to survive restarts
    status_file /var/lib/caddy/maintenance.json
    # Retry-After header value in seconds
    retry_after 300
  }
}
```