### PR TITLE
Allowed ip cidr notation and support for `allowed_ips_file` directive

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@
 ## ✨ Features
 
 - Maintenance mode toggle via caddy adminAPI
-- IP-based access control
+- IP-based access control with CIDR notation support
 - Custom HTML template support
 - Configurable retry period
+- Request retention mode for seamless maintenance
 
 ## 💡 Benefits
 - Centralized control through Caddy
@@ -49,6 +50,7 @@
 - SEO friendly interruption
 - Perfect for containerized architectures
 - Reduced manual intervention needs
+- Flexible IP access control with CIDR ranges
 
 ## 🔧 Build caddy with plugin
 
@@ -65,8 +67,8 @@ Add the maintenance directive to your Caddyfile:
     maintenance {
       # Path to custom HTML template
       template "/path/to/template.html"
-      # List of IPs that can access during maintenance
-      allowed_ips 192.168.1.100 10.0.0.1
+      # List of IPs that can access during maintenance (supports CIDR notation)
+      allowed_ips 192.168.1.100 10.0.0.1 192.168.5.0/22
       # Retry-After header value in seconds (default: 300)
       retry_after 3600
     }
@@ -78,11 +80,37 @@ Add the maintenance directive to your Caddyfile:
 | Option | Description | Required |
 |--------|-------------|----------|
 | `template` | Path to custom HTML template | No |
-| `allowed_ips` | List of IPs that can access during maintenance | No |
+| `allowed_ips` | List of IPs that can access during maintenance (supports CIDR notation) | No |
 | `retry_after` | Retry-After header value in seconds | No |
 | `default_enabled` | Enable maintenance mode by default at startup | No |
 | `status_file` | Path to file for persisting maintenance status | No |
 | `request_retention_mode_timeout` | Time in seconds to retain requests during maintenance | No |
+
+### IP Access Control with CIDR Support
+
+The `allowed_ips` directive supports both individual IP addresses and CIDR notation for network ranges, with full IPv4 and IPv6 support:
+
+```caddy
+maintenance {
+  # Individual IP addresses (IPv4 and IPv6)
+  allowed_ips 192.168.1.100 10.0.0.50 2001:db8::1 ::1
+  
+  # CIDR network ranges (IPv4 and IPv6)
+  allowed_ips 192.168.5.0/22 10.0.1.0/24 172.16.0.0/16 2001:db8::/32
+  
+  # Mixed individual IPs and CIDR ranges
+  allowed_ips 192.168.1.100 192.168.5.0/22 10.0.1.0/24 2001:db8::/32
+}
+```
+
+**CIDR Examples:**
+- `192.168.5.0/22` - Allows IPv4 addresses from 192.168.5.0 to 192.168.7.255
+- `10.0.1.0/24` - Allows IPv4 addresses from 10.0.1.0 to 10.0.1.255
+- `172.16.0.0/16` - Allows IPv4 addresses from 172.16.0.0 to 172.16.255.255
+- `2001:db8::/32` - Allows IPv6 addresses in the 2001:db8::/32 range
+- `::/128` - Allows only the IPv6 loopback address (::1)
+
+**Important:** The plugin uses the client's direct IP address (`r.RemoteAddr`) and does not evaluate proxy headers like `X-Forwarded-For` or `X-Real-IP`. If your server is behind a proxy, you must whitelist the proxy's IP address rather than the original client IPs.
 
 ## 🚀 API Reference
 
@@ -136,7 +164,7 @@ preprod.example.com {
 }
 ```
 
-### Persistent Maintenance Status
+### Persistent Maintenance Status with Network Access Control
 
 ```caddy
 example.com {
@@ -145,10 +173,26 @@ example.com {
     status_file /var/lib/caddy/maintenance.json
     # Retry-After header value in seconds
     retry_after 300
+    # Allow office network and specific IPs
+    allowed_ips 192.168.1.100 192.168.5.0/22 10.0.1.0/24 172.16.0.0/16
   }
 }
 ```
 
+### Corporate Network Access During Maintenance
+
+```caddy
+corporate.example.com {
+  maintenance {
+    # Allow entire corporate network ranges
+    allowed_ips 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
+    # Allow specific external IPs
+    allowed_ips 192.168.1.50 10.0.0.100
+    # Custom maintenance template
+    template "/etc/caddy/maintenance-corporate.html"
+  }
+}
+```
 
 ## Real World Use Cases
 
@@ -162,7 +206,7 @@ example.com {
 **Solution**:
 The maintenance plugin enables seamless maintenance mode activation by:
 1. Toggling maintenance mode through a simple API call to Caddy's admin interface
-2. Instantly cutting off all incoming traffic
+2. Instantly cutting off all incoming traffic (except allowed IPs/networks)
 3. Displaying a maintenance page to all users
 4. Safely performing required maintenance tasks, deployment, container rebuilds, etc.
 5. Restoring service when ready
@@ -179,6 +223,20 @@ The maintenance plugin enables seamless maintenance mode activation by:
 2. Caddy instantly retain incoming requests for the predefined period until maintenance mode is disabled or display a maintenance page if timeout is reached
 3. Toggling maintenance off through API, the retained requests are released and forwarded to the backend
 
+### Corporate Network Access During Maintenance
+
+**Scenario**:
+- Corporate website with internal and external users
+- Need to perform maintenance while allowing internal staff access
+- Multiple office locations with different network ranges
+
+**Solution**:
+The maintenance plugin with CIDR support allows:
+1. Configure network ranges for all office locations (e.g., `10.0.0.0/8`, `172.16.0.0/12`)
+2. Allow specific external IPs for remote workers
+3. Enable maintenance mode while internal users continue working
+4. External users see maintenance page
+5. Seamless maintenance without business interruption
 
 ### Automated Maintenance Based on Critical Services Health
 
@@ -196,7 +254,6 @@ The maintenance plugin can be integrated with Docker health checks:
 2. Custom script watches for health status changes
 3. Maintenance mode automatically triggered when critical service fails
 4. System remains protected until services are healthy again
-
 
 ## 👩‍💻 Development
 


### PR DESCRIPTION
Allowed ip cidr notation and support for `allowed_ips_file` directive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying allowed IP addresses and CIDR ranges from an external file in addition to inline configuration.
  * Enhanced IP-based access control to support both IPv4 and IPv6 CIDR notation for more flexible network management.

* **Documentation**
  * Updated documentation to explain the new allowed IPs file option, provide examples of CIDR usage, and clarify proxy and real-world scenarios.

* **Tests**
  * Expanded and improved tests to cover individual IPs, CIDR ranges, file-based configurations, error handling, and Caddyfile parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->