### PR TITLE
add basic auth management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Variables
 BINARY_NAME=caddy
 BUILD_DIR=build
-XCADDY=xcaddy
-MODULE_PATH=github.com/e-frogg/frops-caddy-maintenance
+XCADDY=~/go/bin/xcaddy
+MODULE_PATH=github.com/e-frogg/fops-caddy-maintenance
 
 # Colors for terminal output
 GREEN=\033[0;32m

--- a/build/Caddyfile
+++ b/build/Caddyfile
@@ -1,9 +1,11 @@
 {
     order maintenance first
+    debug
 }
 
 localhost {
     maintenance {
+        default_enabled true
     }
 
     respond "Hello world!"

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/caddyserver/caddy/v2 v2.10.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/crypto v0.36.0
 )
 
 require (
@@ -105,7 +106,6 @@ require (
 	go.uber.org/mock v0.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap/exp v0.3.0 // indirect
-	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/crypto/x509roots/fallback v0.0.0-20250305170421-49bf5b80c810 // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/mod v0.24.0 // indirect


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HTTP Basic Authentication during maintenance mode, allowing access with credentials stored in an htpasswd file.
  * Introduced new configuration options for specifying authentication realm and htpasswd file.

* **Documentation**
  * Expanded README with detailed instructions for configuring IP allowlists and HTTP Basic Authentication, including examples and usage notes.
  * Clarified access control priority and updated documentation to reflect new features.
  * Removed some example use case sections from the README.

* **Bug Fixes**
  * Corrected a typo in the module path for build configuration.

* **Chores**
  * Updated build configuration and dependency management for improved reliability.

* **Tests**
  * Added comprehensive tests for HTTP Basic Authentication, htpasswd file parsing, and combined access control scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->